### PR TITLE
Update blubr to new logr version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mattermost/blubr
 go 1.13
 
 require (
-	github.com/go-logr/logr v0.4.0
+	github.com/go-logr/logr v1.2.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,12 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
-github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/log_test.go
+++ b/log_test.go
@@ -4,41 +4,57 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
 var logrus = log.NewEntry(log.New())
-var defaultLogger = &logrusLogger{
-	l:    logrus,
-	name: "default",
-}
 
 func TestNewLogger(t *testing.T) {
-	newLogger := newLogger(defaultLogger)
-	assert.Equal(t, newLogger, defaultLogger)
+	var defaultLogger = &logrusLogger{
+		logger:       logrus,
+		defaultLevel: log.InfoLevel,
+		name:         "default",
+	}
+
+	newLog := newLogger(defaultLogger)
+	assert.Equal(t, newLog, defaultLogger)
 
 	// Change the newLogger and make sure the original isn't modified.
-	newLogger.name = "newName"
-	assert.NotEqual(t, newLogger, defaultLogger)
+	newLog.name = "newName"
+	assert.NotEqual(t, newLog, defaultLogger)
 }
 
 func TestEnabled(t *testing.T) {
-	logger := InitLogger()
-	assert.True(t, logger.Enabled())
+	logger := InitLogger(log.NewEntry(log.New()))
+	assert.True(t, logger.Enabled(3))
+	assert.True(t, logger.Enabled(1))
+	assert.False(t, logger.Enabled(6))
+
+	l := log.New()
+	l.SetLevel(log.TraceLevel)
+	logger = InitLogger(log.NewEntry(l))
+	assert.True(t, logger.Enabled(6))
 }
 
 func TestLevel(t *testing.T) {
 	levelTests := []int{-1000, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100, 1000}
 	for _, level := range levelTests {
-		t.Run(fmt.Sprintf("level-%d", level), func(t *testing.T) {
-			logger := InitLogger()
-			assert.NotPanics(t, func() { logger.V(level) })
+		t.Run(fmt.Sprintf("defaultLevel-%d", level), func(t *testing.T) {
+			logger := InitLogger(log.NewEntry(log.New()))
+			assert.NotPanics(t, func() { logger.Info(level, "") })
 		})
 	}
 }
 
 func TestParseFields(t *testing.T) {
+	var defaultLogger = &logrusLogger{
+		logger:       logrus,
+		defaultLevel: log.InfoLevel,
+		name:         "default",
+	}
+
 	var parseTests = []struct {
 		name     string
 		args     []string
@@ -81,9 +97,27 @@ func TestParseFields(t *testing.T) {
 			}
 			assert.Equal(
 				t,
-				parseFields(defaultLogger.l, tt.name, args),
+				parseFields(defaultLogger.logger, tt.name, args),
 				tt.expected,
 			)
 		})
 	}
+}
+
+func TestWithLogr(t *testing.T) {
+	initLogger := InitLogger(log.NewEntry(log.New()))
+	logger := logr.New(initLogger)
+	logger.Info("logging")
+
+	// Make sure new loggers do not panic and level propagates
+
+	withVals := logger.WithValues("test", "test")
+	withVals.Info("logging with values")
+	assert.True(t, withVals.GetSink().Enabled(int(log.InfoLevel)))
+	assert.False(t, withVals.GetSink().Enabled(int(log.TraceLevel)))
+
+	withName := withVals.WithName("test-logget")
+	withName.Info("logging with values and name")
+	assert.True(t, withVals.GetSink().Enabled(int(log.InfoLevel)))
+	assert.False(t, withVals.GetSink().Enabled(int(log.TraceLevel)))
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
`go-logr` reached the version `v1.2.2` which was a breaking change from the version used by blubr. Recent versions of `controller-runtime` are using the new version, so to bump it in Operator, we need to bring blubr up to speed.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

